### PR TITLE
Add command line support to flashing tool

### DIFF
--- a/flash_tool/flash-tool.py
+++ b/flash_tool/flash-tool.py
@@ -1,6 +1,9 @@
 import serial.tools.list_ports
 import serial, time
 import sys
+import os
+
+VERSION = "1.0.0"
 
 comPorts = []
 hexFileData = []
@@ -295,7 +298,7 @@ def flash_data(state):
 				state = 99
 
 
-def main():	
+def main(argv):	
 
 	# TODO:4
 	# 	Option 2: Open COM port selected (not hardcoded)
@@ -330,6 +333,55 @@ def main():
 			exit()
 
 			
+help_string = """
+-P : serial port, e.g -P COM1
+-B : serial baudrate, the value must be in 0-250K interval
+-H : HEX path, use the absolute path of file
+-T : target address, the value must be less or equal to 5 e.g ABCDE
+-h : help, prints this message
+--v : tool version
+-V : verbose mode, prints debugging messages during script execution """
+_commands = {
+	"-P" : ["",		lambda x: "COM" == x[:3] and x[3:].isdigit(),		"-P: The supported port is COMx where x must be an unsigned int"],
+	"-B" : ["",     lambda x: int(x,10) > 0 and int(x,10) <= 250000, 	"-B: The baud rate should be in 0-250000 range" ],
+	"-H" : ["", 	lambda x: x != "" and os.path.isfile(x), 			"-H: File not found"],
+	"-T" : ["",		lambda x: x != "" and len(x) <= 5,					"-T: The length of TX/RX address must be less or equal to 5"],
+	"-h" : ["-",	lambda x: True,										help_string],
+	"--v": ["-",	lambda x: True,                                    	"--v: Tool version is: " + VERSION],
+	"-V" : ["-",	lambda x: False,									"-V: Run in verbose mode"]
+}			
 
 if __name__== "__main__":
-  	main()
+    command_err = 0
+    print(sys.argv)
+    for arg in sys.argv:
+        if arg in _commands:
+            try:
+                if _commands[arg][0] == "-":
+                    if _commands[arg][1](0) == True:
+                        print(_commands[arg][2])
+                    _commands[arg][0] = "*"
+                else:
+                    idx = sys.argv.index(arg)
+                    value = sys.argv[idx + 1]
+                    if _commands[arg][1](value) == False:
+                        print(_commands[arg][2])
+                        command_err = 1
+                    else:
+                        _commands[arg][0] = value
+            except Exception as e:
+                print(_commands[arg][0] + ":command error, use -h to see the correct usage")
+                command_err = 1
+                print(e)
+	
+    #print(_commands)
+    for cmd in _commands:
+        if _commands[cmd][0] == "":
+            print("The " + cmd + " parameter is mandatory!")
+            command_err = 1
+
+    if command_err == 0:
+        main(_commands)
+    else:
+        print("Invalid command, please use -h to see the correct usage")
+


### PR DESCRIPTION
This extends the tool so it can be used from command line or scripts. The features are:

- new commands can be added efficiently without to impact the functionality
- it supports both, flags and parameters e.g. -V sets the verbose mode and -B 9600 sets the baud rate to 9600
- each command has a build in verification function, so each parameter is verified to avoid the wrong values

To add a new command you have to do:

1. add a new entry in **_commands** dictionary, the entry must be a list e.g. "CMD" = [ command value, verification function, error message]. The verification function can be any defined function that returns a boolean value (also you can use lambda functions if the verification is simple). The command value and the error must be strings and CMD must begin with '-'  e.g. -P
2. add a description in **help_string** using the following format: -CMD: summary, additional explanation. e.g. -R: rx address, the length must be less than or equal to 5
3. If you want to add a flag instead of  adding a parameter, then you should use the following format: ["-", lambda_verification, "Error message"]. "-" is the default value and it means that the flag hasn't been set by the user yet. If the flag is passed to the command line, then the value will be changed to "\*" and this can be read in program so some functionalities will be disabled or enabled based on that e.g. -V enables the verbose mode and the value will be changed to "*"